### PR TITLE
アバター画像のmaxScale修正

### DIFF
--- a/lib/presentation/pages/repo/components/avatar_preview_view.dart
+++ b/lib/presentation/pages/repo/components/avatar_preview_view.dart
@@ -43,7 +43,7 @@ class _AvatarPreviewView extends ConsumerWidget {
           repo.avatarUrl,
           cacheManager: cacheManager,
         ),
-        maxScale: 1,
+        maxScale: 1.0,
         backgroundDecoration: const BoxDecoration(),
       ),
     );


### PR DESCRIPTION
## 概要
- アバター画像画面で使用しているPhotoViewのmaxScaleが1だとintとして認識されてエラーになっている
<img src="https://user-images.githubusercontent.com/43258118/184143647-c3acbd19-9b21-4195-bd18-535da91ce435.png" width="300">

### やったこと
- maxScaleを1から1.0に変更
